### PR TITLE
[rebased] Added filters (sort and search) on manifest and build listing

### DIFF
--- a/server/src/action/build/list.js
+++ b/server/src/action/build/list.js
@@ -21,11 +21,11 @@ class ListBuild extends AbstractAction {
       query('sort')
         .optional()
         .isString().withMessage('must be a string')
-        .isIn(['creation', 'start', 'end']).withMessage('sort by creation, start, end'),
+        .isIn(['creation', 'start', 'end']).withMessage('sort should either be "creation", "start" or "end"'),
       query('dir')
         .optional()
         .isString().withMessage('must be a string')
-        .isIn(['asc', 'desc']).withMessage('direction is asc or desc')
+        .isIn(['asc', 'desc']).withMessage('direction should either be "asc" or "desc"')
     ]
   }
 
@@ -37,7 +37,7 @@ class ListBuild extends AbstractAction {
     }
     // Default filters
     const sort = sortToColumnName[req.query.sort || 'creation']
-    // Default direction is DESCENDING only if sort by creation
+    // Default direction is DESCENDING only if we are sorting by creation date
     const dir = req.query.dir || (sort === 'creation_date' ? 'desc' : 'asc')
     const filters = {
       queuing: req.query.queuing || null,

--- a/server/src/action/build/list.js
+++ b/server/src/action/build/list.js
@@ -1,12 +1,52 @@
 const AbstractAction = require('../abstract')
+const { query } = require('express-validator/check')
+const { sanitizeQuery } = require('express-validator/filter')
+const lowercase = require('../sanitizer/lowercase')
 
 class ListBuild extends AbstractAction {
   get validate () {
-    return []
+    return [
+      sanitizeQuery('sort')
+        .customSanitizer(lowercase),
+      sanitizeQuery('dir')
+        .customSanitizer(lowercase),
+      sanitizeQuery('queuing')
+        .toBoolean(),
+      sanitizeQuery('running')
+        .toBoolean(),
+      sanitizeQuery('manifest_id')
+        .toInt(),
+      sanitizeQuery('exit_status')
+        .toInt(),
+      query('sort')
+        .optional()
+        .isString().withMessage('must be a string')
+        .isIn(['creation', 'start', 'end']).withMessage('sort by creation, start, end'),
+      query('dir')
+        .optional()
+        .isString().withMessage('must be a string')
+        .isIn(['asc', 'desc']).withMessage('direction is asc or desc')
+    ]
   }
 
   async handler (req, res, next) {
-    return this.app.controller.build.list()
+    const sortToColumnName = {
+      'creation': 'creation_date',
+      'start': 'start_date',
+      'end': 'end_date'
+    }
+    // Default filters
+    const sort = sortToColumnName[req.query.sort || 'creation']
+    // Default direction is DESCENDING only if sort by creation
+    const dir = req.query.dir || (sort === 'creation_date' ? 'desc' : 'asc')
+    const filters = {
+      queuing: req.query.queuing || null,
+      running: req.query.running || null,
+      manifestId: req.query.manifest_id || null,
+      exitStatus: req.query.exit_status || null
+    }
+
+    return this.app.controller.build.list(sort, dir, filters)
   }
 }
 

--- a/server/src/action/manifest/list.js
+++ b/server/src/action/manifest/list.js
@@ -1,12 +1,39 @@
 const AbstractAction = require('../abstract')
+const { query } = require('express-validator/check')
+const { sanitizeQuery } = require('express-validator/filter')
+const lowercase = require('../sanitizer/lowercase')
 
 class ListManifest extends AbstractAction {
   get validate () {
-    return []
+    return [
+      sanitizeQuery('sort')
+        .customSanitizer(lowercase),
+      sanitizeQuery('dir')
+        .customSanitizer(lowercase),
+      query('sort')
+        .optional()
+        .isString().withMessage('must be a string')
+        .isIn(['name', 'creation', 'update']).withMessage('sort by name, creation or update'),
+      query('dir')
+        .optional()
+        .isString().withMessage('must be a string')
+        .isIn(['asc', 'desc']).withMessage('direction is asc or desc')
+    ]
   }
 
   async handler (req, res, next) {
-    return this.app.controller.manifest.list()
+    const sortToColumnName = {
+      'name': 'name',
+      'creation': 'creation_date',
+      'update': 'last_update'
+    }
+    // Default filters
+    const name = req.query.name || ''
+    const sort = sortToColumnName[req.query.sort || 'creation']
+    // Default direction is DESCENDING only if sort by creation
+    const dir = req.query.dir || (sort === 'creation_date' ? 'desc' : 'asc')
+
+    return this.app.controller.manifest.list(name, sort, dir)
   }
 }
 

--- a/server/src/action/manifest/list.js
+++ b/server/src/action/manifest/list.js
@@ -17,7 +17,7 @@ class ListManifest extends AbstractAction {
       query('dir')
         .optional()
         .isString().withMessage('must be a string')
-        .isIn(['asc', 'desc']).withMessage('direction is asc or desc')
+        .isIn(['asc', 'desc']).withMessage('direction should either be "asc" or "desc"')
     ]
   }
 
@@ -30,7 +30,7 @@ class ListManifest extends AbstractAction {
     // Default filters
     const name = req.query.name || ''
     const sort = sortToColumnName[req.query.sort || 'creation']
-    // Default direction is DESCENDING only if sort by creation
+    // Default direction is DESCENDING only if we are sorting by creation date
     const dir = req.query.dir || (sort === 'creation_date' ? 'desc' : 'asc')
 
     return this.app.controller.manifest.list(name, sort, dir)

--- a/server/src/action/sanitizer/lowercase.js
+++ b/server/src/action/sanitizer/lowercase.js
@@ -1,0 +1,3 @@
+module.exports = (value) => {
+  return value.toLowerCase()
+}

--- a/server/src/controller/build.js
+++ b/server/src/controller/build.js
@@ -119,9 +119,23 @@ class BuildController {
     return build.toJSON()
   }
 
-  // TODO: filters
-  async list () {
+  async list (sort, direction, filters) {
     const builds = await this.app.database.model.build
+      .query(queryBuilder => {
+        if (filters.queuing !== null) {
+          queryBuilder.where('queuing', filters.queuing)
+        }
+        if (filters.running !== null) {
+          queryBuilder.where('running', filters.running)
+        }
+        if (filters.manifestId !== null) {
+          queryBuilder.where('manifest_id', '@>', [filters.manifestId])
+        }
+        if (filters.exitStatus !== null) {
+          queryBuilder.where('exit_status', filters.exitStatus)
+        }
+      })
+      .orderBy(sort, direction)
       .fetchAll()
 
     return builds.toJSON()

--- a/server/src/controller/manifest.js
+++ b/server/src/controller/manifest.js
@@ -71,9 +71,10 @@ class ManifestController {
     return manifest.toJSON()
   }
 
-  // TODO: filters
-  async list () {
+  async list (name, sort, direction) {
     const manifests = await this.app.database.model.manifest
+      .where('name', 'LIKE', name + '%')
+      .orderBy(sort, direction)
       .fetchAll({ withRelated: ['history'] })
 
     return manifests.toJSON()

--- a/server/src/routing.js
+++ b/server/src/routing.js
@@ -43,7 +43,7 @@ class Routing {
     let errorParam = []
     if (details) {
       for (let param of Object.keys(details)) {
-        errorParam.push({ param, detail: details[param].msg })
+        errorParam.push({ param, detail: details[param].msg, value: details[param].value })
       }
     }
     console.error('[error]', err.stack)


### PR DESCRIPTION
Closes #14
Closes #24

For manifest listing:
sort by (name, creation update) and search by name

For build listing:
sort by (creation, start, end) and search by queuing, running, manifest_id and exit_status

