### PR TITLE
server: add missing bad request error

### DIFF
--- a/server/src/errors/bad-request.js
+++ b/server/src/errors/bad-request.js
@@ -1,0 +1,11 @@
+const CustomError = require('./custom-error')
+
+class BadRequest extends CustomError {
+  constructor (message, ...args) {
+    super(message || 'Bad request', ...args)
+    this.status = 400
+    this.name = 'Bad Request'
+  }
+}
+
+module.exports = BadRequest

--- a/server/src/errors/index.js
+++ b/server/src/errors/index.js
@@ -1,10 +1,12 @@
 const NotFound = require('./not-found')
 const Forbidden = require('./forbidden')
+const BadRequest = require('./bad-request')
 
 class Errors {
   constructor (app) {
     this.NotFound = NotFound
     this.Forbidden = Forbidden
+    this.BadRequest = BadRequest
   }
 }
 


### PR DESCRIPTION
There was an error when the builder tried to use a bad request error
that didn't exist